### PR TITLE
Fix code scanning alert no. 8: Uncontrolled data used in path expression

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -99,7 +99,8 @@ class EventsController < ApplicationController
     return redirect_to event_path(@event), notice: I18n.t('only_csv_files_allowed') unless params[:file].content_type == 'text/csv'
 
     if @event
-      import = CsvExhibitImport.call(@event, params[:file])
+      sanitized_file = ActiveStorage::Filename.new(params[:file].original_filename).sanitized
+      import = CsvExhibitImport.call(@event, sanitized_file)
       redirect_to event_path(@event),
                   notice: I18n.t('moc_data_imported_stats_notice', import: import[:ignore_count], import2: import[:failure_count], import3: import[:success_count]),
                   alert: import[:errors].size > 0 ? I18n.t('failed_moc_ids', inspect: import[:errors].inspect) : nil

--- a/app/services/csv_exhibit_import.rb
+++ b/app/services/csv_exhibit_import.rb
@@ -15,7 +15,7 @@ class CsvExhibitImport < ApplicationService
     success_count = 0;
     failure_count = 0
     errors = []
-    opened_file = File.open(@file)
+    opened_file = File.open(Rails.root.join('tmp', @file))
     options = { headers: true, col_sep: ';' }
     CSV.foreach(opened_file, **options) do |row|
 


### PR DESCRIPTION
Fixes [https://github.com/thoherr/brickevent/security/code-scanning/8](https://github.com/thoherr/brickevent/security/code-scanning/8)

To fix the problem, we need to validate and sanitize the user input before using it to construct a file path. We can use the `ActiveStorage::Filename#sanitized` method in Rails to ensure that the file name is safe to use. This method will remove any potentially dangerous characters from the file name.

1. In the `EventsController`, sanitize the `params[:file]` before passing it to the `CsvExhibitImport` service.
2. Update the `CsvExhibitImport` service to handle the sanitized file name.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
