### PR TITLE
Add database indexes for improved query performance

### DIFF
--- a/db/migrate/20251104195936_add_performance_indexes.rb
+++ b/db/migrate/20251104195936_add_performance_indexes.rb
@@ -1,0 +1,29 @@
+class AddPerformanceIndexes < ActiveRecord::Migration[8.1]
+  def change
+    # Events table indexes
+    # Index for event listing query: where("lug_id = ? and (registration_open = ? or visible = ?)")
+    add_index :events, [:lug_id, :registration_open, :visible],
+              name: 'index_events_on_lug_and_registration_and_visibility'
+    # Index for default_scope ordering by start_date DESC
+    add_index :events, :start_date
+
+    # Visitors table indexes
+    # Index for session lookup: Visitor.find_by(session_id: session_id)
+    add_index :visitors, :session_id, unique: true
+
+    # AttendeeTypes table indexes
+    # Index for name lookup: AttendeeType.find_by_name('Aussteller')
+    add_index :attendee_types, :name
+
+    # Exhibits table indexes
+    # Indexes for commonly filtered boolean fields
+    add_index :exhibits, :is_approved
+    add_index :exhibits, :is_collab
+    add_index :exhibits, :is_installation
+    add_index :exhibits, :is_part_of_installation
+
+    # Attendees table indexes
+    # Index for approval filtering
+    add_index :attendees, :is_approved
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_11_03_194756) do
+ActiveRecord::Schema[8.1].define(version: 2025_11_04_195936) do
   create_table "accommodation_types", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.string "description"
@@ -46,6 +46,7 @@ ActiveRecord::Schema[8.1].define(version: 2025_11_03_194756) do
     t.boolean "is_visible"
     t.string "name"
     t.datetime "updated_at", precision: nil, null: false
+    t.index ["name"], name: "index_attendee_types_on_name"
   end
 
   create_table "attendees", force: :cascade do |t|
@@ -70,6 +71,7 @@ ActiveRecord::Schema[8.1].define(version: 2025_11_03_194756) do
     t.datetime "updated_at", precision: nil, null: false
     t.index ["attendance_id"], name: "index_attendees_on_attendance_id"
     t.index ["attendee_type_id"], name: "index_attendees_on_attendee_type_id"
+    t.index ["is_approved"], name: "index_attendees_on_is_approved"
   end
 
   create_table "builders", force: :cascade do |t|
@@ -126,7 +128,9 @@ ActiveRecord::Schema[8.1].define(version: 2025_11_03_194756) do
     t.datetime "updated_at", precision: nil, null: false
     t.string "url"
     t.boolean "visible"
+    t.index ["lug_id", "registration_open", "visible"], name: "index_events_on_lug_and_registration_and_visibility"
     t.index ["lug_id"], name: "index_events_on_lug_id"
+    t.index ["start_date"], name: "index_events_on_start_date"
   end
 
   create_table "exhibits", force: :cascade do |t|
@@ -179,6 +183,10 @@ ActiveRecord::Schema[8.1].define(version: 2025_11_03_194756) do
     t.index ["attendance_id"], name: "index_exhibits_on_attendance_id"
     t.index ["former_exhibit_id"], name: "index_exhibits_on_former_exhibit_id"
     t.index ["installation_exhibit_id"], name: "index_exhibits_on_installation_exhibit_id"
+    t.index ["is_approved"], name: "index_exhibits_on_is_approved"
+    t.index ["is_collab"], name: "index_exhibits_on_is_collab"
+    t.index ["is_installation"], name: "index_exhibits_on_is_installation"
+    t.index ["is_part_of_installation"], name: "index_exhibits_on_is_part_of_installation"
     t.index ["unit_id"], name: "index_exhibits_on_unit_id"
   end
 
@@ -236,6 +244,7 @@ ActiveRecord::Schema[8.1].define(version: 2025_11_03_194756) do
     t.datetime "created_at", null: false
     t.string "session_id"
     t.datetime "updated_at", null: false
+    t.index ["session_id"], name: "index_visitors_on_session_id", unique: true
   end
 
   create_table "votes", force: :cascade do |t|


### PR DESCRIPTION
This migration adds 9 new indexes to optimize frequently queried columns:

Events table:
- Composite index on (lug_id, registration_open, visible) for event listing query
- Index on start_date for default_scope ordering

Visitors table:
- Unique index on session_id for visitor lookup during voting

AttendeeTypes table:
- Index on name for AttendeeType.find_by_name('Aussteller')

Exhibits table:
- Index on is_approved for filtering approved exhibits
- Index on is_collab for filtering collaborative exhibits
- Index on is_installation for filtering installation exhibits
- Index on is_part_of_installation for filtering installation parts

Attendees table:
- Index on is_approved for filtering approved attendees

Performance Impact:
- Event listing queries will use composite index instead of full table scan
- Visitor session lookups will be O(1) with unique index
- Boolean filtering on exhibits/attendees will use index lookups
- AttendeeType name lookups will be faster with index

All tests pass: 131 runs, 374 assertions, 0 failures Coverage maintained at 95.58%

🤖 Generated with [Claude Code](https://claude.com/claude-code)